### PR TITLE
Add admin UI for managing new API response headers defaults & overrides

### DIFF
--- a/app/assets/javascripts/admin/models/api/settings.js
+++ b/app/assets/javascripts/admin/models/api/settings.js
@@ -13,6 +13,8 @@ Admin.ApiSettings = Ember.Model.extend({
   authenticatedRateLimitBehavior: Ember.attr(),
   passApiKeyHeader: Ember.attr(),
   passApiKeyQueryParam: Ember.attr(),
+  defaultResponseHeadersString: Ember.attr(),
+  overrideResponseHeadersString: Ember.attr(),
   errorTemplates: Ember.attr(),
   errorDataYamlStrings: Ember.attr(),
 

--- a/app/assets/javascripts/admin/templates/apis/_form.hbs
+++ b/app/assets/javascripts/admin/templates/apis/_form.hbs
@@ -80,7 +80,7 @@
           inputConfig='class:span12'}}
         {{input headersString as='text'
           class='row-fluid'
-          label='Set Headers'
+          label='Set Request Headers'
           placeholder='X-Example-Header: value'
           inputConfig='class:span12'}}
         {{input httpBasicAuth

--- a/app/assets/javascripts/admin/templates/apis/settings_fields.hbs
+++ b/app/assets/javascripts/admin/templates/apis/settings_fields.hbs
@@ -19,7 +19,7 @@
 <div class="control-group">
   <div class="control-label">
     <label>Pass API Key to Backend (deprecated)</label>
-    {{tooltip-field title="<p>Whether to pass the user's api key to this API backend.</p><p><strong><em>Deprecated:</em></strong> This is deprecated and support of this will be removed in the future. Enabling either option is not recommend.</p><p>If your API backend needs to uniquely reference the requesting user, use the <code>X-Api-User-Id</code> HTTP header instead.</p><p><em>Note:</em> Passing via GET query parameter with render API Umbrella's HTTP caching layer mostly ineffectual (since the cache will be mainted per api key)."}}
+    {{tooltip-field title="<p>Whether to pass the user's api key to this API backend.</p><p><strong><em>Deprecated:</em></strong> This is deprecated and support of this will be removed in the future. Enabling either option is not recommend.</p><p>If your API backend needs to uniquely reference the requesting user, use the <code>X-Api-User-Id</code> HTTP header instead.</p><p><em>Note:</em> Passing via GET query parameter with render API Umbrella's HTTP caching layer mostly ineffectual (since the cache will be maintained per api key)."}}
   </div>
   <div class="controls">
     <label class="checkbox">
@@ -34,3 +34,20 @@
 </div>
 
 {{render 'apis/settings_rate_limit_fields' this}}
+
+{{input defaultResponseHeadersString as='text'
+  class='row-fluid'
+  label='Default Response Headers'
+  placeholder='X-Example-Header: value'
+  tooltip='<p>Define header values that will be set in the response regardless of whether the header is already set in the response.</p>
+<p>For example, to set default CORS headers on all responses that don\'t explicitly set their own CORS headers:</p>
+<pre>Access-Control-Allow-Origin: *</pre>'
+  inputConfig='class:span12'}}
+{{input overrideResponseHeadersString as='text'
+  class='row-fluid'
+  label='Override Response Headers'
+  placeholder='X-Example-Header: value'
+  tooltip='<p>Define header values that will be set in the response regardless of whether the header is already set in the response.</p>
+<p>For example, to force CORS headers on all responses:</p>
+<pre>Access-Control-Allow-Origin: *</pre>'
+  inputConfig='class:span12'}}

--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -85,7 +85,7 @@ class Api
 
   def as_json(options)
     options[:methods] ||= []
-    options[:methods] += [:error_data_yaml_strings, :headers_string]
+    options[:methods] += [:error_data_yaml_strings, :headers_string, :default_response_headers_string, :override_response_headers_string]
 
     json = super(options)
 

--- a/lib/api_umbrella/attributify_data.rb
+++ b/lib/api_umbrella/attributify_data.rb
@@ -49,7 +49,7 @@ module ApiUmbrella
       settings_data = data["settings_attributes"]
       old_settings_data = old_data["settings"] if(old_data.present?)
 
-      %w(headers rate_limits).each do |collection_name|
+      %w(headers rate_limits default_response_headers override_response_headers).each do |collection_name|
         attributify_embeds_many!(settings_data, collection_name, old_settings_data)
       end
     end


### PR DESCRIPTION
This is a generic implementation of modifying response headers at the proxy layer which can be used t force CORS headers.

Related to https://github.com/18F/api.data.gov/issues/120 and https://github.com/NREL/api-umbrella/issues/81