### PR TITLE
Implement new HTTPS requirement behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,6 +126,9 @@ gem "premailer-rails", "~> 1.8.0"
 # Localization in the admin based on the Accept-Language header
 gem "http_accept_language", "~> 2.0.2"
 
+# Markdown
+gem "kramdown", "~> 1.6.0"
+
 group :production, :staging do
   # Log to stdout instead of file
   gem "rails_stdout_logging", "~> 0.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
     kaminari-bootstrap (0.1.3)
       kaminari (>= 0.13.0)
       rails
+    kramdown (1.6.0)
     libv8 (3.16.14.7)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -520,6 +521,7 @@ DEPENDENCIES
   jshintrb (~> 0.2.4)!
   kaminari (~> 0.16.1)
   kaminari-bootstrap (~> 0.1.3)
+  kramdown (~> 1.6.0)
   mongoid (~> 3.1.6)
   mongoid-embedded-errors (~> 2.0.1)
   mongoid_delorean (~> 1.3.0)

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -64,7 +64,7 @@ $(document).ready(function() {
         event: 'unfocus'
       },
       style: {
-        classes: 'qtip-bootstrap',
+        classes: 'qtip-bootstrap ' + $(this).data('tooltip-class'),
       },
       position: {
         viewport: true,

--- a/app/assets/javascripts/admin/app.js
+++ b/app/assets/javascripts/admin/app.js
@@ -87,9 +87,45 @@ window.Admin = Ember.Application.create({
   rootElement: '#content'
 });
 
+function eachTranslatedAttribute(object, fn) {
+  var isTranslatedAttribute = /(.+)Translation$/,
+      isTranslatedAttributeMatch;
+
+  for (var key in object) {
+    isTranslatedAttributeMatch = key.match(isTranslatedAttribute);
+    if (isTranslatedAttributeMatch) {
+      var translation = object[key] == null ? null : polyglot.t(object[key]);
+      fn.call(object, isTranslatedAttributeMatch[1], translation);
+    }
+  }
+}
+
+// Override existing Ember.EasyForm.processOptions to use our polyglot
+// translations instead of Ember.i18n for the special *Translation fields.
+//
+// We could also potentially use subexpressions to call polyglot directly in
+// the templates, but at least as of Ember 1.7, there are bugs with multiple
+// subexpressions: https://github.com/wycats/handlebars.js/issues/748
+// Perhaps revisit when we upgrade Ember.
+Ember.EasyForm.processOptions = function(property, options) {
+  if(options) {
+    if(polyglot) {
+      eachTranslatedAttribute(options.hash, function(attribute, translation) {
+        options.hash[attribute] = translation;
+        delete options.hash[attribute + 'Translation'];
+      });
+    }
+    options.hash.property = property;
+  } else {
+    options = property;
+  }
+
+  return options;
+};
+
 Ember.EasyForm.Tooltip = Ember.EasyForm.BaseView.extend({
   tagName: 'a',
-  attributeBindings: ['title', 'rel'],
+  attributeBindings: ['title', 'rel', 'data-tooltip-class'],
   template: Ember.Handlebars.compile('<i class="fa fa-question-circle"></i>'),
   rel: 'tooltip',
 });
@@ -127,7 +163,7 @@ Ember.Handlebars.registerHelper('tooltip-field', function(property, options) {
 
 // Use a custom template for Easy Form. This adds a tooltip and wraps that in
 // the control-label div with the label.
-Ember.TEMPLATES['easyForm/wrapped_input'] = Ember.Handlebars.compile('<div class="control-label">{{label-field propertyBinding="view.property" textBinding="view.label"}}{{#if view.tooltip}}{{tooltip-field titleBinding="view.tooltip"}}{{/if}}</div><div class="{{unbound view.controlsWrapperClass}}">{{partial "easyForm/inputControls"}}</div>');
+Ember.TEMPLATES['easyForm/wrapped_input'] = Ember.Handlebars.compile('<div class="control-label">{{label-field propertyBinding="view.property" textBinding="view.label"}}{{#if view.tooltip}}{{tooltip-field titleBinding="view.tooltip" data-tooltip-classBinding="view.tooltipClass"}}{{/if}}</div><div class="{{unbound view.controlsWrapperClass}}">{{partial "easyForm/inputControls"}}</div>');
 
 Ember.EasyForm.Config.registerInputType('ace', Ember.EasyForm.TextArea.extend({
   attributeBindings: ['data-ace-mode'],

--- a/app/assets/javascripts/admin/app.js
+++ b/app/assets/javascripts/admin/app.js
@@ -94,7 +94,7 @@ function eachTranslatedAttribute(object, fn) {
   for (var key in object) {
     isTranslatedAttributeMatch = key.match(isTranslatedAttribute);
     if (isTranslatedAttributeMatch) {
-      var translation = object[key] == null ? null : polyglot.t(object[key]);
+      var translation = (!object[key]) ? null : polyglot.t(object[key]);
       fn.call(object, isTranslatedAttributeMatch[1], translation);
     }
   }

--- a/app/assets/javascripts/admin/controllers/apis/settings_fields_controller.js
+++ b/app/assets/javascripts/admin/controllers/apis/settings_fields_controller.js
@@ -1,14 +1,17 @@
 Admin.ApisSettingsFieldsController = Ember.ObjectController.extend({
   requireHttpsOptions: [
-    { id: null, name: 'Inherit (default - optional)' },
-    { id: false, name: 'Optional - HTTPS is optional' },
-    { id: true, name: 'Required - HTTPS is mandatory' },
+    { id: null, name: polyglot.t('admin.api.settings.require_https_options.inherit') },
+    { id: 'required_return_error', name: polyglot.t('admin.api.settings.require_https_options.required_return_error') },
+    { id: 'required_return_redirect', name: polyglot.t('admin.api.settings.require_https_options.required_return_redirect') },
+    { id: 'transition_return_error', name: polyglot.t('admin.api.settings.require_https_options.transition_return_error') },
+    { id: 'transition_return_redirect', name: polyglot.t('admin.api.settings.require_https_options.transition_return_redirect') },
+    { id: 'optional', name: polyglot.t('admin.api.settings.require_https_options.optional') },
   ],
 
   disableApiKeyOptions: [
-    { id: null, name: 'Inherit (default - required)' },
-    { id: false, name: 'Required - API keys are mandatory' },
-    { id: true, name: 'Disabled - API keys are optional' },
+    { id: null, name: polyglot.t('admin.api.settings.disable_api_key_options.inherit') },
+    { id: false, name: polyglot.t('admin.api.settings.disable_api_key_options.required') },
+    { id: true, name: polyglot.t('admin.api.settings.disable_api_key_options.disabled') },
   ],
 
   roleOptions: function() {

--- a/app/assets/javascripts/admin/templates/apis/settings_fields.hbs
+++ b/app/assets/javascripts/admin/templates/apis/settings_fields.hbs
@@ -1,15 +1,21 @@
 {{input requireHttps as='select'
   value='requireHttps'
-  label='HTTPS Requirements'
+  class='row-fluid'
+  labelTranslation='admin.api.settings.require_https'
+  tooltipClass='qtip-wide'
+  tooltipTranslation='admin.api.settings.require_https_tooltip'
   collection='requireHttpsOptions'
   optionValuePath='content.id'
-  optionLabelPath='content.name'}}
+  optionLabelPath='content.name'
+  inputConfig='class:span12'}}
 {{input disableApiKey as='select'
   value='disableApiKey'
+  class='row-fluid'
   label='API Key Checks'
   collection='disableApiKeyOptions'
   optionValuePath='content.id'
-  optionLabelPath='content.name'}}
+  optionLabelPath='content.name'
+  inputConfig='class:span12'}}
 {{#view Admin.SelectizeView valueBinding='requiredRolesString' contentBinding='roleOptions' optionValuePath='id' optionLabelPath='id'}}
   {{input requiredRolesString
     class='row-fluid'

--- a/app/assets/stylesheets/admin/base.css.scss
+++ b/app/assets/stylesheets/admin/base.css.scss
@@ -464,7 +464,7 @@ td.reorder-handle {
 }
 
 .qtip-wide {
-  max-width: 600px;
+  max-width: 700px;
 }
 
 .qtip-forced-wide {

--- a/app/controllers/api/v1/config_controller.rb
+++ b/app/controllers/api/v1/config_controller.rb
@@ -18,6 +18,8 @@ class Api::V1::ConfigController < Api::V1::BaseController
       api = Api.unscoped.find(api_id)
       authorize(api, :publish?)
 
+      api.handle_transition_https_on_publish!
+
       new_config["apis"].reject! { |data| data["_id"] == api_id }
       unless api.deleted_at?
         new_config["apis"] << api.attributes_hash

--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -131,6 +131,25 @@ class Api
     true
   end
 
+  def handle_transition_https_on_publish!
+    changed = false
+    if(self.settings)
+      self.settings.set_require_https_transition_start_at_on_publish
+    end
+
+    if(self.sub_settings)
+      self.sub_settings.each do |sub|
+        if(sub.settings)
+          sub.settings.set_require_https_transition_start_at_on_publish
+        end
+      end
+    end
+
+    if(self.changed?)
+      self.save!
+    end
+  end
+
   def roles
     roles = []
 

--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -132,7 +132,6 @@ class Api
   end
 
   def handle_transition_https_on_publish!
-    changed = false
     if(self.settings)
       self.settings.set_require_https_transition_start_at_on_publish
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,33 @@ en:
         note: Modify the incoming request's URL or headers before passing it to the backend.
         empty_list: No request rewrites have been added yet. Click "%{add}" below to get started.
         add: Add Rewrite
+      settings:
+        require_https: HTTPS Requirements
+        require_https_tooltip: |-
+          Choose whether HTTPS is required to access this API. HTTPS is encouraged to protect the API keys.
+
+          - **Required & return message:** HTTPS is required to access the API. HTTP requests will return an error message instructing the user to use an HTTPS URL instead. This is the recommended and default strategy.
+          - **Required & return redirect:** HTTPS is required to access the API. HTTP requests will return a redirect to the HTTPS URL.
+          - **Transitionary & return message:** New API keys that signup after choosing this setting will be forced to use HTTPS. Existing API keys may continue to use either HTTP or HTTPS. New API keys using HTTP will return an error message instructing the user to use an HTTPS URL instead.
+          - **Transitionary & return redirect:** New API keys that signup after choosing this setting will be forced to use HTTPS. Existing API keys may continue to use either HTTP or HTTPS. New API keys using HTTP will return a redirect to the HTTPS URL.
+          - **Optional**: HTTPS is optional and either HTTP or HTTPS may be used.
+
+          *Notes on redirects:*
+
+          - Not all API clients will automatically follow redirects, so be careful if using a redirect strategy for existing APIs (since existing calls may break).
+          - If API clients rely on the redirect for HTTPS access, this strategy does not secure the API keys, since the client may still be making an insecure initial HTTP request with their API key.
+          - For GET requests a `301 Moved Permanently` redirect will be returned. For all other HTTP methods a `307 Temporary Redirect` redirect will be returned (to instruct the client to retry using the same HTTP method).
+        require_https_options:
+          inherit: Inherit (default - required & return message)
+          required_return_error: Required & return message - HTTP requests will receive a message to use HTTPS
+          required_return_redirect: Required & return redirects - HTTP requests will be redirected to HTTPS
+          transition_return_error: Transitionary & return message - Optional for existing API keys, required for new API keys
+          transition_return_redirect: Transitionary & return redirects - Optional for existing API keys, required for new API keys
+          optional: Optional - HTTPS is optional
+        disable_api_key_options:
+          inherit: Inherit (default - required)
+          required: Required - API keys are mandatory
+          disabled: Disabled - API keys are optional
       sub_settings:
         legend: Sub-URL Request Settings
         note: Change settings for specific sub-URLs within this API.

--- a/db/migrate/20150327071153_require_https_settings.rb
+++ b/db/migrate/20150327071153_require_https_settings.rb
@@ -1,0 +1,27 @@
+class RequireHttpsSettings < Mongoid::Migration
+  def self.up
+    # The require_https setting that was previously present in the web admin UI
+    # was non-functional. So migrate any existing true/false/nil values to the
+    # new "optional" setting to replicate the old non-functional behavior.
+    Api.all.each do |api|
+      if(api.settings.present? && !api.settings.require_https.kind_of?(String))
+        api.settings.require_https = "optional"
+      end
+
+      if(api.sub_settings.present?)
+        api.sub_settings.each do |sub|
+          if(sub.settings.present? && !sub.settings.require_https.kind_of?(String))
+            sub.settings.require_https = "optional"
+          end
+        end
+      end
+
+      if(api.changed?)
+        api.save!
+      end
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Now each API backend can choose to require HTTPS with either an error message instructing the user to use HTTPS or a redirect. There's also support for a "transition" mode where existing API keys can continue calling the API via HTTP, but all new api keys must use HTTPS.

Related to https://github.com/18F/api.data.gov/issues/34