### PR TITLE
Add admin interface for managing website backend configurations

### DIFF
--- a/app/assets/javascripts/admin/controllers/config/publish_controller.js
+++ b/app/assets/javascripts/admin/controllers/config/publish_controller.js
@@ -3,10 +3,14 @@ Admin.ConfigPublishController = Ember.Controller.extend({
     var newApis = this.get('model.config.apis.new');
     var modifiedApis = this.get('model.config.apis.modified');
     var deletedApis = this.get('model.config.apis.deleted');
-    if(newApis.length > 0 || modifiedApis.length > 0 || deletedApis.length > 0) {
+    var newWebsiteBackends = this.get('model.config.website_backends.new');
+    var modifiedWebsiteBackends = this.get('model.config.website_backends.modified');
+    var deletedWebsiteBackends = this.get('model.config.website_backends.deleted');
+
+    if(newApis.length > 0 || modifiedApis.length > 0 || deletedApis.length > 0 || newWebsiteBackends.length > 0 || modifiedWebsiteBackends.length > 0 || deletedWebsiteBackends.length > 0) {
       return true;
     } else {
       return false;
     }
-  }.property('model.config.apis.new.@each', 'model.config.apis.modified.@each', 'model.config.apis.deleted.@each'),
+  }.property('model.config.apis.new.@each', 'model.config.apis.modified.@each', 'model.config.apis.deleted.@each', 'model.config.website_backends.new.@each', 'model.config.website_backends.modified.@each', 'model.config.website_backends.deleted.@each'),
 });

--- a/app/assets/javascripts/admin/controllers/website_backends/form_controller.js
+++ b/app/assets/javascripts/admin/controllers/website_backends/form_controller.js
@@ -1,0 +1,41 @@
+Admin.WebsiteBackendsFormController = Ember.ObjectController.extend(Admin.Save, {
+  backendProtocolOptions: [
+    { id: 'http', name: 'http' },
+    { id: 'https', name: 'https' },
+  ],
+
+  changeDefaultPort: function() {
+    var protocol = this.get('model.backendProtocol');
+    var port = parseInt(this.get('model.serverPort'), 10);
+    if(protocol === 'https') {
+      if(!port || port === 80) {
+        this.set('model.serverPort', 443);
+      }
+    } else {
+      if(!port || port === 443) {
+        this.set('model.serverPort', 80);
+      }
+    }
+  }.observes('model.backendProtocol'),
+
+  actions: {
+    submit: function() {
+      this.save({
+        transitionToRoute: 'website_backends',
+        message: 'Successfully saved the "' + this.get('model.frontendHost') + '" website backend<br><strong>Note:</strong> Your changes are not yet live. <a href="/admin/#/config/publish">Publish Changes</a> to send your updates live.',
+      });
+    },
+
+    delete: function() {
+      bootbox.confirm('Are you sure you want to delete this website backend?', _.bind(function(result) {
+        if(result) {
+          this.get('model').deleteRecord();
+          this.transitionToRoute('website_backends');
+        }
+      }, this));
+    },
+  },
+});
+
+Admin.WebsiteBackendsEditController = Admin.WebsiteBackendsFormController.extend();
+Admin.WebsiteBackendsNewController = Admin.WebsiteBackendsFormController.extend();

--- a/app/assets/javascripts/admin/models/website_backend.js
+++ b/app/assets/javascripts/admin/models/website_backend.js
@@ -1,0 +1,38 @@
+Admin.WebsiteBackend = Ember.Model.extend(Ember.Validations.Mixin, {
+  id: Ember.attr(),
+  frontendHost: Ember.attr(),
+  backendProtocol: Ember.attr(),
+  serverHost: Ember.attr(),
+  serverPort: Ember.attr(Number),
+
+  validations: {
+    frontendHost: {
+      presence: true,
+      format: {
+        with: CommonValidations.frontend_host_format,
+        message: polyglot.t('errors.messages.invalid_host_format'),
+      },
+    },
+    backendProtocol: {
+      presence: true,
+    },
+    serverHost: {
+      presence: true,
+      format: {
+        with: CommonValidations.frontend_host_format,
+        message: polyglot.t('errors.messages.invalid_host_format'),
+      },
+    },
+    serverPort: {
+      presence: true,
+      numericality: true,
+    },
+  },
+});
+
+Admin.WebsiteBackend.url = '/api-umbrella/v1/website_backends';
+Admin.WebsiteBackend.rootKey = 'website_backend';
+Admin.WebsiteBackend.collectionKey = 'data';
+Admin.WebsiteBackend.primaryKey = 'id';
+Admin.WebsiteBackend.camelizeKeys = true;
+Admin.WebsiteBackend.adapter = Admin.APIUmbrellaRESTAdapter.create();

--- a/app/assets/javascripts/admin/router.js
+++ b/app/assets/javascripts/admin/router.js
@@ -41,4 +41,9 @@ Admin.Router.map(function() {
     this.route('map', { path: '/map/*query' });
     this.route('mapDefault', { path: '/map' });
   });
+
+  this.resource('website_backends', { path: '/website_backends' }, function() {
+    this.route('new');
+    this.route('edit', { path: '/:websiteBackendId/edit' });
+  });
 });

--- a/app/assets/javascripts/admin/routes/website_backends/base_route.js
+++ b/app/assets/javascripts/admin/routes/website_backends/base_route.js
@@ -1,0 +1,8 @@
+Admin.WebsiteBackendsBaseRoute = Ember.Route.extend({
+  setupController: function(controller, model) {
+    controller.set('model', model);
+
+    $('ul.nav li').removeClass('active');
+    $('ul.nav li.nav-config').addClass('active');
+  },
+});

--- a/app/assets/javascripts/admin/routes/website_backends/edit_route.js
+++ b/app/assets/javascripts/admin/routes/website_backends/edit_route.js
@@ -1,0 +1,10 @@
+Admin.WebsiteBackendsEditRoute = Admin.WebsiteBackendsBaseRoute.extend({
+  model: function(params) {
+    // Clear the record cache, so this is always fetched from the server (to
+    // account for two users simultaneously editing the same record).
+    Admin.WebsiteBackend.clearCache();
+
+    return Admin.WebsiteBackend.find(params.websiteBackendId);
+  },
+});
+

--- a/app/assets/javascripts/admin/routes/website_backends/index_route.js
+++ b/app/assets/javascripts/admin/routes/website_backends/index_route.js
@@ -1,0 +1,2 @@
+Admin.WebsiteBackendsIndexRoute = Admin.WebsiteBackendsBaseRoute.extend({
+});

--- a/app/assets/javascripts/admin/routes/website_backends/new_route.js
+++ b/app/assets/javascripts/admin/routes/website_backends/new_route.js
@@ -1,0 +1,8 @@
+Admin.WebsiteBackendsNewRoute = Admin.WebsiteBackendsBaseRoute.extend({
+  model: function() {
+    return Admin.WebsiteBackend.create({
+      serverPort: 80,
+    });
+  },
+});
+

--- a/app/assets/javascripts/admin/templates/config/publish.hbs
+++ b/app/assets/javascripts/admin/templates/config/publish.hbs
@@ -5,21 +5,42 @@
     {{#if model.config.apis.new}}
       <fieldset>
         <legend>{{model.config.apis.new.length}} New API Backends</legend>
-        {{render "config/publish_api" model.config.apis.new}}
+        {{render "config/publish_record" model.config.apis.new category="apis"}}
+      </fieldset>
+    {{/if}}
+
+    {{#if model.config.website_backends.new}}
+      <fieldset>
+        <legend>{{model.config.website_backends.new.length}} New Website Backends</legend>
+        {{render "config/publish_record" model.config.website_backends.new category="website_backends"}}
       </fieldset>
     {{/if}}
 
     {{#if model.config.apis.modified}}
       <fieldset>
         <legend>{{model.config.apis.modified.length}} Modified API Backends</legend>
-        {{render "config/publish_api" model.config.apis.modified}}
+        {{render "config/publish_record" model.config.apis.modified category="apis"}}
+      </fieldset>
+    {{/if}}
+
+    {{#if model.config.website_backends.modified}}
+      <fieldset>
+        <legend>{{model.config.website_backends.modified.length}} Modified Website Backends</legend>
+        {{render "config/publish_record" model.config.website_backends.modified category="website_backends"}}
       </fieldset>
     {{/if}}
 
     {{#if model.config.apis.deleted}}
       <fieldset>
         <legend>{{model.config.apis.deleted.length}} Deleted API Backends</legend>
-        {{render "config/publish_api" model.config.apis.deleted}}
+        {{render "config/publish_record" model.config.apis.deleted category="apis"}}
+      </fieldset>
+    {{/if}}
+
+    {{#if model.config.website_backends.deleted}}
+      <fieldset>
+        <legend>{{model.config.website_backends.deleted.length}} Deleted Website Backends</legend>
+        {{render "config/publish_record" model.config.website_backends.deleted category="website_backends"}}
       </fieldset>
     {{/if}}
 

--- a/app/assets/javascripts/admin/templates/config/publish_record.hbs
+++ b/app/assets/javascripts/admin/templates/config/publish_record.hbs
@@ -10,11 +10,11 @@
       {{#each model}}
         <tr>
           <td class="text-center">
-            <input type="hidden" name="config[apis][{{unbound id}}][mode]" {{bind-attr value='mode'}} />
-            <input type="hidden" name="config[apis][{{unbound id}}][active_version]" {{bind-attr value='active.version'}} />
-            <input type="hidden" name="config[apis][{{unbound id}}][pending_version]" {{bind-attr value='pending.version'}} />
-            <input type="hidden" name="config[apis][{{unbound id}}][publish]" value="0" />
-            <input type="checkbox" name="config[apis][{{unbound id}}][publish]" value="1" />
+            <input type="hidden" name="config[{{unbound view.category}}][{{unbound id}}][mode]" {{bind-attr value='mode'}} />
+            <input type="hidden" name="config[{{unbound view.category}}][{{unbound id}}][active_version]" {{bind-attr value='active.version'}} />
+            <input type="hidden" name="config[{{unbound view.category}}][{{unbound id}}][pending_version]" {{bind-attr value='pending.version'}} />
+            <input type="hidden" name="config[{{unbound view.category}}][{{unbound id}}][publish]" value="0" />
+            <input type="checkbox" name="config[{{unbound view.category}}][{{unbound id}}][publish]" value="1" />
           </td>
           <td>{{name}}<br><small><a href="#" {{action 'toggleConfigDiff' id target='view'}}>View Config Differences</a></small></td>
         </tr>

--- a/app/assets/javascripts/admin/templates/website_backends/_form.hbs
+++ b/app/assets/javascripts/admin/templates/website_backends/_form.hbs
@@ -1,0 +1,38 @@
+{{error-messages model=model}}
+
+{{#form-for model}}
+  <fieldset class="form-horizontal info">
+    {{input frontendHost
+      label='Frontend Host'
+      placeholder='example.com'
+      inputConfig='class:span6'}}
+
+    {{input backendProtocol as='select'
+      label=(t 'mongoid.attributes.api.backend_protocol')
+      value='backendProtocol'
+      collection='backendProtocolOptions'
+      optionValuePath='content.id'
+      optionLabelPath='content.name'}}
+
+    {{input serverHost
+      label='Backend Server'
+      placeholder='example.github.io'
+      inputConfig='class:span6'}}
+
+    {{input serverPort
+      label='Backend Port'
+      inputConfig='class:span2'}}
+  </fieldset>
+
+  <div class="row-fluid">
+    <div class="span6">
+      <button type="submit" id="save_button" class="btn btn-large btn-primary" data-loading-text="<i class='fa fa-refresh fa-spin'></i> Saving...">Save</button>
+    </div>
+    <div class="span6 record-details">
+      {{#if id}}
+        Created: {{formatDate createdAt}} by {{creator.username}}<br>
+        Last Updated: {{formatDate updatedAt}} by {{updater.username}}<br>
+      {{/if}}
+    </div>
+  </div>
+{{/form-for}}

--- a/app/assets/javascripts/admin/templates/website_backends/edit.hbs
+++ b/app/assets/javascripts/admin/templates/website_backends/edit.hbs
@@ -1,0 +1,2 @@
+<h1>Edit Website Backend</h1>
+{{partial "website_backends/form"}}

--- a/app/assets/javascripts/admin/templates/website_backends/index.hbs
+++ b/app/assets/javascripts/admin/templates/website_backends/index.hbs
@@ -1,0 +1,9 @@
+<h1>Website Backends</h1>
+
+<div class="button-actions button-actions-down">
+  <a href="#/website_backends/new" class="btn btn-primary"><i class="fa fa-plus"></i> Add Website Backend</a>
+</div>
+
+<div id="results_table searchable-table-with-add">
+  {{view Admin.WebsiteBackendsTableView}}
+</div>

--- a/app/assets/javascripts/admin/templates/website_backends/new.hbs
+++ b/app/assets/javascripts/admin/templates/website_backends/new.hbs
@@ -1,0 +1,2 @@
+<h1>Add Website Backend</h1>
+{{partial "website_backends/form"}}

--- a/app/assets/javascripts/admin/views/config/publish_api_view.js
+++ b/app/assets/javascripts/admin/views/config/publish_api_view.js
@@ -1,7 +1,0 @@
-Admin.ConfigPublishApiView = Ember.View.extend({
-  actions: {
-    toggleConfigDiff: function(apiId) {
-      $('[data-diff-id=' + apiId + ']').toggle();
-    }
-  }
-});

--- a/app/assets/javascripts/admin/views/config/publish_record_view.js
+++ b/app/assets/javascripts/admin/views/config/publish_record_view.js
@@ -1,0 +1,7 @@
+Admin.ConfigPublishRecordView = Ember.View.extend({
+  actions: {
+    toggleConfigDiff: function(id) {
+      $('[data-diff-id=' + id + ']').toggle();
+    }
+  }
+});

--- a/app/assets/javascripts/admin/views/website_backends/table_view.js
+++ b/app/assets/javascripts/admin/views/website_backends/table_view.js
@@ -1,0 +1,31 @@
+Admin.WebsiteBackendsTableView = Ember.View.extend({
+  tagName: 'table',
+  classNames: ['table', 'table-striped', 'table-bordered', 'table-condensed'],
+
+  didInsertElement: function() {
+    this.set('table', this.$().DataTable({
+      serverSide: true,
+      ajax: '/api-umbrella/v1/website_backends.json',
+      pageLength: 50,
+      rowCallback: function(row, data) {
+        $(row).data('id', data.id);
+      },
+      order: [[0, 'asc']],
+      columns: [
+        {
+          data: 'frontend_host',
+          title: 'Host',
+          defaultContent: '-',
+          render: _.bind(function(name, type, data) {
+            if(type === 'display' && name && name !== '-') {
+              var link = '#/website_backends/' + data.id + '/edit';
+              return '<a href="' + link + '">' + _.escape(name) + '</a>';
+            }
+
+            return name;
+          }, this),
+        },
+      ]
+    }));
+  },
+});

--- a/app/controllers/api/v1/config_controller.rb
+++ b/app/controllers/api/v1/config_controller.rb
@@ -19,11 +19,11 @@ class Api::V1::ConfigController < Api::V1::BaseController
         next unless(record_params[:publish].to_s == "1")
 
         record = case(category)
-        when "apis"
-          Api.unscoped.find(record_id)
-        when "website_backends"
-          WebsiteBackend.unscoped.find(record_id)
-        end
+                 when "apis"
+                   Api.unscoped.find(record_id)
+                 when "website_backends"
+                   WebsiteBackend.unscoped.find(record_id)
+                 end
 
         authorize(record, :publish?)
 

--- a/app/controllers/api/v1/config_controller.rb
+++ b/app/controllers/api/v1/config_controller.rb
@@ -10,21 +10,32 @@ class Api::V1::ConfigController < Api::V1::BaseController
   def publish
     active_config = ConfigVersion.active_config || {}
     new_config = active_config.deep_dup
-    new_config["apis"] ||= []
 
-    params[:config][:apis].each do |api_id, api_params|
-      next unless(api_params[:publish].to_s == "1")
+    ["apis", "website_backends"].each do |category|
+      new_config[category] ||= []
+      next unless(params[:config].present? && params[:config][category].present?)
 
-      api = Api.unscoped.find(api_id)
-      authorize(api, :publish?)
+      params[:config][category].each do |record_id, record_params|
+        next unless(record_params[:publish].to_s == "1")
 
-      new_config["apis"].reject! { |data| data["_id"] == api_id }
-      unless api.deleted_at?
-        new_config["apis"] << api.attributes_hash
+        record = case(category)
+        when "apis"
+          Api.unscoped.find(record_id)
+        when "website_backends"
+          WebsiteBackend.unscoped.find(record_id)
+        end
+
+        authorize(record, :publish?)
+
+        new_config[category].reject! { |data| data["_id"] == record_id }
+        unless record.deleted_at?
+          new_config[category] << record.attributes_hash
+        end
       end
     end
 
     new_config["apis"].sort_by! { |data| data["sort_order"].to_i }
+    new_config["website_backends"].sort_by! { |data| data["frontend_host"].to_i }
 
     @config_version = ConfigVersion.publish!(new_config)
     respond_with(:api_v1, @config_version, :root => "config_version", :location => api_v1_config_pending_changes_url)

--- a/app/controllers/api/v1/website_backends_controller.rb
+++ b/app/controllers/api/v1/website_backends_controller.rb
@@ -1,0 +1,53 @@
+class Api::V1::WebsiteBackendsController < Api::V1::BaseController
+  respond_to :json
+
+  skip_after_filter :verify_authorized, :only => [:index]
+
+  def index
+    @website_backends = policy_scope(WebsiteBackend).order_by(datatables_sort_array)
+
+    if(params[:order].blank?)
+      @website_backends = @website_backends.order_by(:name.asc)
+    end
+
+    if(params[:start].present?)
+      @website_backends = @website_backends.skip(params[:start].to_i)
+    end
+
+    if(params[:length].present?)
+      @website_backends = @website_backends.limit(params[:length].to_i)
+    end
+
+    if(params[:search] && params[:search][:value].present?)
+      @website_backends = @website_backends.or([
+        { :frontend_host => /#{params[:search][:value]}/i },
+        { :server_host => /#{params[:search][:value]}/i },
+      ])
+    end
+  end
+
+  def show
+    @website_backend = WebsiteBackend.find(params[:id])
+    authorize(@website_backend)
+  end
+
+  def create
+    @website_backend = WebsiteBackend.new
+    save!
+    respond_with(:api_v1, @website_backend, :root => "website_backend")
+  end
+
+  def update
+    @website_backend = WebsiteBackend.find(params[:id])
+    save!
+    respond_with(:api_v1, @website_backend, :root => "website_backend")
+  end
+
+  private
+
+  def save!
+    @website_backend.assign_attributes(params[:website_backend], :as => :admin)
+    authorize(@website_backend)
+    @website_backend.save
+  end
+end

--- a/app/models/config_version.rb
+++ b/app/models/config_version.rb
@@ -63,11 +63,11 @@ class ConfigVersion
       # Grab all APIs, including "deleted" ones so we can determine what API
       # deletions still need to be published.
       pending_records = case(category)
-      when "apis"
-        Api.unscoped
-      when "website_backends"
-        WebsiteBackend.unscoped
-      end
+                        when "apis"
+                          Api.unscoped
+                        when "website_backends"
+                          WebsiteBackend.unscoped
+                        end
 
       if(current_admin)
         pending_records = Pundit.policy_scope!(current_admin, pending_records)
@@ -131,11 +131,11 @@ class ConfigVersion
         mode_changes.each do |change|
           change["id"] = if(change["pending"]) then change["pending"]["_id"] else change["active"]["_id"] end
           change["name"] = case(category)
-          when "apis"
-            if(change["pending"]) then change["pending"]["name"] else change["active"]["name"] end
-          when "website_backends"
-            if(change["pending"]) then change["pending"]["frontend_host"] else change["active"]["frontend_host"] end
-          end
+                           when "apis"
+                             if(change["pending"]) then change["pending"]["name"] else change["active"]["name"] end
+                           when "website_backends"
+                             if(change["pending"]) then change["pending"]["frontend_host"] else change["active"]["frontend_host"] end
+                           end
           change["active_yaml"] = pretty_dump(change["active"])
           change["pending_yaml"] = pretty_dump(change["pending"])
         end

--- a/app/models/website_backend.rb
+++ b/app/models/website_backend.rb
@@ -1,0 +1,43 @@
+require "common_validations"
+
+class WebsiteBackend
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
+  include Mongoid::Userstamp
+  include Mongoid::Delorean::Trackable
+
+  # Fields
+  field :_id, :type => String, :default => lambda { UUIDTools::UUID.random_create.to_s }
+  field :frontend_host, :type => String
+  field :backend_protocol, :type => String
+  field :server_host, :type => String
+  field :server_port, :type => Integer
+
+  # Validations
+  validates :frontend_host,
+    :presence => true,
+    :format => {
+      :with => CommonValidations::FRONTEND_HOST_FORMAT,
+      :message => :invalid_host_format,
+    }
+  validates :backend_protocol,
+    :inclusion => { :in => %w(http https) }
+  validates :server_host,
+    :presence => true,
+    :format => {
+      :with => CommonValidations::HOST_FORMAT,
+      :message => :invalid_host_format,
+    }
+  validates :server_port,
+    :presence => true,
+    :inclusion => { :in => 0..65_535 }
+
+  def self.sorted
+    order_by(:frontend_host.asc)
+  end
+
+  def attributes_hash
+    Hash[self.attributes]
+  end
+end

--- a/app/policies/website_backend_policy.rb
+++ b/app/policies/website_backend_policy.rb
@@ -1,0 +1,55 @@
+class WebsiteBackendPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if(user.superuser?)
+        scope.all
+      else
+        api_scopes = user.api_scopes_with_permission("backend_manage")
+
+        query_scopes = []
+        api_scopes.each do |api_scope|
+          if(api_scope.path_prefix.blank? || api_scope.path_prefix == "/")
+            query_scopes << {
+              :frontend_host => api_scope.host,
+            }
+          end
+        end
+
+        scope.or(query_scopes)
+      end
+    end
+  end
+
+  def show?
+    can?("backend_manage")
+  end
+
+  def update?
+    show?
+  end
+
+  def create?
+    show?
+  end
+
+  def publish?
+    can?("backend_publish")
+  end
+
+  private
+
+  def can?(permission)
+    allowed = false
+    if(user.superuser?)
+      allowed = true
+    else
+      api_scopes = user.api_scopes_with_permission(permission)
+
+      allowed = api_scopes.any? do |api_scope|
+        (record.frontend_host == api_scope.host && (api_scope.path_prefix.blank? || api_scope.path_prefix == "/"))
+      end
+    end
+
+    allowed
+  end
+end

--- a/app/views/api/v1/config/pending_changes.json.jbuilder
+++ b/app/views/api/v1/config/pending_changes.json.jbuilder
@@ -1,3 +1,1 @@
-json.config do
-  json.apis @changes
-end
+json.config @changes

--- a/app/views/api/v1/website_backends/index.rabl
+++ b/app/views/api/v1/website_backends/index.rabl
@@ -1,0 +1,10 @@
+object false
+
+node(:draw) { params[:draw].to_i }
+node(:recordsTotal) { @website_backends.count }
+node(:recordsFiltered) { @website_backends.count }
+node :data do
+  @website_backends.map do |website_backend|
+    website_backend.serializable_hash
+  end
+end

--- a/app/views/api/v1/website_backends/show.rabl
+++ b/app/views/api/v1/website_backends/show.rabl
@@ -1,0 +1,16 @@
+object @website_backend
+attributes :id,
+           :frontend_host,
+           :backend_protocol,
+           :server_host,
+           :server_port,
+           :created_at,
+           :updated_at
+
+child :creator => :creator do
+  attributes :username
+end
+
+child :updater => :updater do
+  attributes :username
+end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -60,6 +60,7 @@
               <%= tab.config(%(#{t("admin.nav.configuration")} <b class="caret"></b>).html_safe, "#", :class => "dropdown nav-config", :link_html => { :class => "dropdown-toggle", "data-toggle" => "dropdown" }) do %>
                 <ul class="dropdown-menu">
                   <li><%= link_to(%(<i class="fa fa-gear"></i> #{t("admin.nav.api_backends")}).html_safe, '/admin/#/apis') %></li>
+                  <li><%= link_to(%(<i class="fa fa-gear"></i> #{t("admin.nav.website_backends")}).html_safe, '/admin/#/website_backends') %></li>
                   <li><%= link_to(%(<i class="fa fa-upload"></i> #{t("admin.nav.publish_changes")}).html_safe, '/admin/#/config/publish') %></li>
                   <li class="divider"></li>
                   <li><%= link_to(%(<i class="fa fa-exchange"></i> #{t("admin.nav.import_export")}).html_safe, admin_config_import_export_path) %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
       permissions_management: Permissions Management
       publish_changes: Publish Changes
       users: Users
+      website_backends: Website Backends
     api:
       servers:
         legend: Backend

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ ApiUmbrella::Application.routes.draw do
         resources :api_scopes
         resources :apis
         resources :users
+        resources :website_backends
         resource :contact, :only => [:create]
 
         resources :analytics do


### PR DESCRIPTION
This allows for serving of different website content depending on the domain. Related to the website routing changes as part of https://github.com/NREL/api-umbrella-router/pull/6 and related to https://github.com/18F/api.data.gov/issues/146