### PR TITLE
Add missing delete action for website backends

### DIFF
--- a/app/assets/javascripts/admin/templates/website_backends/_form.hbs
+++ b/app/assets/javascripts/admin/templates/website_backends/_form.hbs
@@ -35,4 +35,9 @@
       {{/if}}
     </div>
   </div>
+  {{#if id}}
+    <div class="row-fluid form-extra-actions">
+      <a href="#" class="remove-action" {{action 'delete'}}><i class="fa fa-times"></i>Delete Website Backend</a>
+    </div>
+  {{/if}}
 {{/form-for}}

--- a/app/controllers/api/v1/website_backends_controller.rb
+++ b/app/controllers/api/v1/website_backends_controller.rb
@@ -43,6 +43,13 @@ class Api::V1::WebsiteBackendsController < Api::V1::BaseController
     respond_with(:api_v1, @website_backend, :root => "website_backend")
   end
 
+  def destroy
+    @website_backend = WebsiteBackend.find(params[:id])
+    authorize(@website_backend)
+    @website_backend.destroy
+    respond_with(:api_v1, @website_backend, :root => "website_backend")
+  end
+
   private
 
   def save!

--- a/app/policies/website_backend_policy.rb
+++ b/app/policies/website_backend_policy.rb
@@ -32,6 +32,10 @@ class WebsiteBackendPolicy < ApplicationPolicy
     show?
   end
 
+  def destroy?
+    show?
+  end
+
   def publish?
     can?("backend_publish")
   end


### PR DESCRIPTION
As noted in https://github.com/NREL/api-umbrella/issues/134 we were accidentally missing the delete action for the new Website Backends portion of the admin. This adds the missing link and action.