### PR TITLE
Wildcard subdomain support

### DIFF
--- a/app/assets/javascripts/admin/models/api.js
+++ b/app/assets/javascripts/admin/models/api.js
@@ -28,10 +28,17 @@ Admin.Api = Ember.Model.extend(Ember.Validations.Mixin, {
       },
     },
     backendHost: {
-      presence: true,
+      presence: {
+        unless: function(object) {
+          return (object.get('frontendHost') && object.get('frontendHost')[0] === '*');
+        },
+      },
       format: {
         with: CommonValidations.host_format,
         message: polyglot.t('errors.messages.invalid_host_format'),
+        if: function(object) {
+          return !!object.get('backendHost');
+        },
       },
     },
   },

--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -40,10 +40,13 @@ class Api
     }
   validates :backend_host,
     :presence => true,
+    :unless => proc { |record| record.frontend_host.start_with?("*") }
+  validates :backend_host,
     :format => {
       :with => CommonValidations::HOST_FORMAT,
       :message => :invalid_host_format,
-    }
+    },
+    :if => proc { |record| record.backend_host.present? }
   validates :balance_algorithm,
     :inclusion => { :in => %w(round_robin least_conn ip_hash) }
   validates_each :servers, :url_matches do |record, attr, value|

--- a/lib/common_validations.rb
+++ b/lib/common_validations.rb
@@ -1,5 +1,6 @@
 module CommonValidations
-  HOST_FORMAT = %r{^[a-zA-Z0-9:][a-zA-Z0-9\-\.:]*$}
-  FRONTEND_HOST_FORMAT = %r{(#{HOST_FORMAT.source}|^\*$)}
+  BASE_HOST_FORMAT = %r{[a-zA-Z0-9:][a-zA-Z0-9\-\.:]*}
+  HOST_FORMAT = %r{^#{BASE_HOST_FORMAT.source}$}
+  FRONTEND_HOST_FORMAT = %r{^(\*|\*?#{BASE_HOST_FORMAT.source}|\*\.#{BASE_HOST_FORMAT.source})$}
   URL_PREFIX_FORMAT = %r{^/}
 end

--- a/spec/cassettes/elasticsearch_templates.yml
+++ b/spec/cassettes/elasticsearch_templates.yml
@@ -41,13 +41,13 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 14 May 2015 04:03:33 GMT
+      - Mon, 18 May 2015 21:02:17 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-mia1327-MIA
+      - cache-mia1323-MIA
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -55,7 +55,7 @@ http_interactions:
       Vary:
       - Authorization,Accept-Encoding
       Expires:
-      - Thu, 14 May 2015 04:08:33 GMT
+      - Mon, 18 May 2015 21:07:17 GMT
       Source-Age:
       - '0'
     body:
@@ -217,5 +217,5 @@ http_interactions:
           }
         ]
     http_version: 
-  recorded_at: Thu, 14 May 2015 04:03:32 GMT
+  recorded_at: Mon, 18 May 2015 14:42:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/models/api_spec.rb
+++ b/spec/models/api_spec.rb
@@ -153,5 +153,129 @@ describe Api do
       api.errors_on(:backend_host).should include('must be in the format of "example.com"')
       api.errors_on(:"servers[0].host").should include('must be in the format of "example.com"')
     end
+
+    it "allows an empty string backend host when the frontend host is a wildcard" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "*",
+        :backend_host => "",
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(true)
+    end
+
+    it "allows an null backend host when the frontend host is a wildcard" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "*",
+        :backend_host => nil,
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(true)
+    end
+
+    it "allows an empty backend host when the frontend host contains a wildcard with dot" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "*.example.com",
+        :backend_host => nil,
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(true)
+    end
+
+    it "allows an empty backend host when the frontend host contains a wildcard without dot" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "*example.com",
+        :backend_host => nil,
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(true)
+    end
+
+    it "does not allow a frontend host starting with a dot" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => ".example.com",
+        :backend_host => "example.com",
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(false)
+      api.errors.messages.keys.sort.should eql([
+        :frontend_host,
+      ])
+    end
+
+    it "does not allow a frontend host equal to '.'" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => ".",
+        :backend_host => "example.com",
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(false)
+      api.errors.messages.keys.sort.should eql([
+        :frontend_host,
+      ])
+    end
+
+    it "does not allow a frontend host equal to '*.'" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "*.",
+        :backend_host => "example.com",
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(false)
+      api.errors.messages.keys.sort.should eql([
+        :frontend_host,
+      ])
+    end
+
+    it "does not allow an empty backend host when the frontend host does not contain a wildcard" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "example.com",
+        :backend_host => nil,
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(false)
+      api.errors.messages.keys.sort.should eql([
+        :backend_host,
+      ])
+    end
+
+    it "does not allow an empty backend host when the frontend host contains a wildcard in the middle" do
+      api = FactoryGirl.build(:api, {
+        :frontend_host => "exam*ple.com",
+        :backend_host => nil,
+        :servers => [
+          FactoryGirl.attributes_for(:api_server, :host => "127.0.0.1"),
+        ]
+      })
+
+      api.valid?.should eql(false)
+      api.errors.messages.keys.sort.should eql([
+        :backend_host,
+        :frontend_host,
+      ])
+    end
   end
 end


### PR DESCRIPTION
Related to: https://github.com/NREL/api-umbrella-gatekeeper/pull/13

This updates the model validations to allow the backend host to be blank when a wildcard subdomain is being used. When blank, this retains current `Host` header on the original request, which is the simplest way to support dynamic subdomains currently.