### PR TITLE
Default logs filter

### DIFF
--- a/app/assets/javascripts/admin/routes/stats/base_route.js
+++ b/app/assets/javascripts/admin/routes/stats/base_route.js
@@ -4,6 +4,17 @@ Admin.StatsBaseRoute = Ember.Route.extend({
     search: '',
     start_at: moment().subtract(29, 'days').format('YYYY-MM-DD'),
     end_at: moment().format('YYYY-MM-DD'),
+    query: JSON.stringify({
+      condition: 'AND',
+      rules: [{
+        field: 'gatekeeper_denied_code',
+        id: 'gatekeeper_denied_code',
+        input: 'select',
+        operator: 'is_null',
+        type: 'string',
+        value: null
+      }]
+    })
   },
 
   model: function(params) {


### PR DESCRIPTION
For https://github.com/18F/api.data.gov/issues/241

To help alleviate slowness in stats pages due to too many api-over-limit logs, this defaults these logs to _exclude_ logs which had a gatekeeper error message. This should therefore show only "legitimate" traffic on initial view. As the initial view contains a filter, the filters will also start expanded:

![screen shot 2015-06-25 at 5 56 20 pm](https://cloud.githubusercontent.com/assets/326918/8366515/85890496-1b63-11e5-830c-9a89867975ef.png)

This PR also extends an existing spec to test that this initial filter can be removed.