### PR TITLE
Fix multiple logs.json requests being made on analytics form chagnes

### DIFF
--- a/app/assets/javascripts/admin/controllers/stats/base_controller.js
+++ b/app/assets/javascripts/admin/controllers/stats/base_controller.js
@@ -5,13 +5,18 @@ Admin.StatsBaseController = Ember.ObjectController.extend({
 
   actions: {
     submit: function() {
+      var query = this.get('query');
+      query.beginPropertyChanges();
+
       if($('#filter_type_advanced').css('display') === 'none') {
-        this.set('query.params.search', null);
-        this.set('query.params.query', JSON.stringify($('#query_builder').queryBuilder('getRules')));
+        query.set('params.search', '');
+        query.set('params.query', JSON.stringify($('#query_builder').queryBuilder('getRules')));
       } else {
-        this.set('query.params.query', null);
-        this.set('query.params.search', $('#filter_form input[name=search]').val());
+        query.set('params.query', '');
+        query.set('params.search', $('#filter_form input[name=search]').val());
       }
+
+      query.endPropertyChanges();
     },
   },
 });

--- a/app/assets/javascripts/admin/views/stats/logs_table_view.js
+++ b/app/assets/javascripts/admin/views/stats/logs_table_view.js
@@ -152,7 +152,13 @@ Admin.LogsTableView = Ember.View.extend({
     });
   },
 
-  refreshData: function() {
+  redrawTable: function() {
     this.$().DataTable().draw();
+  },
+
+  refreshData: function() {
+    // Wrap datatables redraw in Ember.run.once so that we only trigger it once
+    // even if multiple query parameters are being changed at once.
+    Ember.run.once(this, 'redrawTable');
   }.observes('controller.query.params.query', 'controller.query.params.search', 'controller.query.params.start_at', 'controller.query.params.end_at'),
 });


### PR DESCRIPTION
When we introduced the query builder interface for analytics (https://github.com/NREL/api-umbrella-web/pull/7), it turns out we accidentally started making duplicate requests for the table data. Reported in https://github.com/18F/api.data.gov/issues/250