### PR TITLE
Surface bucket names to the admin UI

### DIFF
--- a/app/assets/javascripts/admin/models/api/url_match.js
+++ b/app/assets/javascripts/admin/models/api/url_match.js
@@ -3,6 +3,7 @@ Admin.ApiUrlMatch = Ember.Model.extend(Ember.Validations.Mixin,{
   sortOrder: Ember.attr(Number),
   frontendPrefix: Ember.attr(),
   backendPrefix: Ember.attr(),
+  rateLimitBucketName: Ember.attr(),
 
   validations: {
     frontendPrefix: {
@@ -18,6 +19,9 @@ Admin.ApiUrlMatch = Ember.Model.extend(Ember.Validations.Mixin,{
         with: CommonValidations.url_prefix_format,
         message: polyglot.t('errors.messages.invalid_url_prefix_format'),
       },
+    },
+    rateLimitBucketName: {
+      length: { maximum: 30 }
     },
   },
 

--- a/app/assets/javascripts/admin/templates/apis/url_match_form.hbs
+++ b/app/assets/javascripts/admin/templates/apis/url_match_form.hbs
@@ -26,6 +26,16 @@
     <h4>Example:</h4>
     <div><strong>Incoming Frontend Request:</strong> {{exampleIncomingUrl}}</div>
     <div><strong>Outgoing Backend Request:</strong> {{exampleOutgoingUrl}}</div>
+
+    <h4>Custom Rate Limit Bucket:</h4>
+    <div class="row-fluid">
+      <p class="fieldset-note">
+        Rate limits are typically applied per frontend domain. You can modify this behavior by designating a "bucket" with which to count requests to this URL.
+      </p>
+      {{input rateLimitBucketName
+        label="Bucket name"
+        inputConfig='class:span12'}}
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn" {{action 'cancel'}}>Cancel</button>

--- a/app/assets/javascripts/admin/templates/apis/url_matches.hbs
+++ b/app/assets/javascripts/admin/templates/apis/url_matches.hbs
@@ -4,6 +4,7 @@
       <tr>
         <th>Frontend Prefix</th>
         <th>Backend Prefix</th>
+        <th>Custom Rate Limit Bucket</th>
         <th></th>
         <th class="reorder-handle"></th>
       </tr>
@@ -14,6 +15,7 @@
           <tr data-id="{{unbound id}}">
             <td>{{frontendPrefix}}</td>
             <td>{{backendPrefixWithDefault}}</td>
+            <td>{{rateLimitBucketName}}</td>
             <td class="table-row-actions" style="width: 90px; white-space: nowrap;">
               <a href="#" {{action 'editUrlMatch' this}}><i class="fa fa-pencil"></i>{{t 'admin.edit'}}</a>
               <a href="#" class="remove-action" {{action 'deleteUrlMatch' this}}><i class="fa fa-times"></i>{{t 'admin.remove'}}</a>

--- a/app/models/api/url_match.rb
+++ b/app/models/api/url_match.rb
@@ -7,11 +7,13 @@ class Api::UrlMatch
   field :_id, :type => String, :default => lambda { UUIDTools::UUID.random_create.to_s }
   field :frontend_prefix, :type => String
   field :backend_prefix, :type => String
+  field :rate_limit_bucket_name, :type => String
 
   # Relations
   embedded_in :api
 
   # Validations
+  before_validation :clean_fields
   validates :frontend_prefix,
     :presence => true,
     :format => {
@@ -24,9 +26,20 @@ class Api::UrlMatch
       :with => CommonValidations::URL_PREFIX_FORMAT,
       :message => :invalid_url_prefix_format,
     }
+  validates :rate_limit_bucket_name,
+    :length => {
+      :maximum => 30
+    }
 
   # Mass assignment security
   attr_accessible :frontend_prefix,
     :backend_prefix,
+    :rate_limit_bucket_name,
     :as => [:default, :admin]
+
+  def clean_fields
+    if self.rate_limit_bucket_name.blank?
+      self.rate_limit_bucket_name = nil
+    end
+  end
 end

--- a/spec/controllers/api/v1/apis_controller_spec.rb
+++ b/spec/controllers/api/v1/apis_controller_spec.rb
@@ -1317,6 +1317,24 @@ describe Api::V1::ApisController do
       end
     end
 
+    it "does not update rate limit bucket field when empty" do
+      admin_token_auth(@admin)
+      attributes = @api.serializable_hash
+      attributes["url_matches"][0]["rate_limit_bucket_name"] = ""
+      put :update, :format => "json", :id => @api.id, :api => attributes
+      @api.reload
+      expect(@api.url_matches[0].rate_limit_bucket_name).to be_nil
+    end
+
+    it "updates rate limit bucket field when non-empty" do
+      admin_token_auth(@admin)
+      attributes = @api.serializable_hash
+      attributes["url_matches"][0]["rate_limit_bucket_name"] = "bouquet" 
+      put :update, :format => "json", :id => @api.id, :api => attributes
+      @api.reload
+      expect(@api.url_matches[0].rate_limit_bucket_name).to eq "bouquet"
+    end
+
     describe "servers" do
       it_behaves_like "validates nested attributes presence - update", :servers
     end

--- a/spec/controllers/api/v1/config_controller_spec.rb
+++ b/spec/controllers/api/v1/config_controller_spec.rb
@@ -74,6 +74,7 @@ describe Api::V1::ConfigController do
           "url_matches",
           "- backend_prefix",
           "  frontend_prefix",
+          "  rate_limit_bucket_name",
         ])
       end
     end

--- a/spec/models/api/url_match_spec.rb
+++ b/spec/models/api/url_match_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Api::UrlMatch do
+  it 'nils-out bucket name if it is blank' do
+    match = FactoryGirl.build(:api_url_match)
+    expect(match.rate_limit_bucket_name).to be_nil
+    match.rate_limit_bucket_name = ""
+    match.valid?
+    expect(match.rate_limit_bucket_name).to be_nil
+    match.rate_limit_bucket_name = "      "
+    match.valid?
+    expect(match.rate_limit_bucket_name).to be_nil
+  end
+end


### PR DESCRIPTION
Finishes up https://github.com/18F/api.data.gov/issues/124

This provides a UI for admins to change the "bucket" name associated with a particular routing path. In affect, they can say that requests for path `/abcd` are counted differently than `/xyz`. Further, if, for whatever reason, multiple frontend domains should share the same rate limit bucket (for example, `api.some.gov` should share the same limits as `app.api.some.gov`), that is now possible to set up through the UI.

Looks like
<img width="1148" alt="screen shot 2015-07-24 at 10 38 42 am" src="https://cloud.githubusercontent.com/assets/326918/8876839/38047d7e-31f0-11e5-9a77-656338331b84.png">
<img width="837" alt="screen shot 2015-07-24 at 10 38 34 am" src="https://cloud.githubusercontent.com/assets/326918/8876840/38040132-31f0-11e5-9aed-a66d1e12ea72.png">

It'd be nice for this to auto-complete (as we do with user roles), but that can implemented later.