### PR TITLE
Setup error data for easier overriding of URL variables

### DIFF
--- a/app/assets/javascripts/admin/templates/apis/_form.hbs
+++ b/app/assets/javascripts/admin/templates/apis/_form.hbs
@@ -121,7 +121,7 @@
 
       {{#with settings}}
         {{#with errorTemplates}}
-          <h4>Error Templates</h4>
+          <h4>{{t 'mongoid.attributes.api/settings.error_templates'}}</h4>
           {{input json as='ace'
             class='row-fluid'
             labelTranslation='admin.api.settings.error_templates_json'
@@ -142,7 +142,13 @@
         {{/with}}
 
         {{#with errorDataYamlStrings}}
-          <h4>Error Data</h4>
+          <h4>{{t 'mongoid.attributes.api/settings.error_data'}}</h4>
+
+          {{input common as='ace'
+            class='row-fluid'
+            labelTranslation='admin.api.settings.error_data_common'
+            tooltipTranslation='admin.api.settings.error_data_common_tooltip_markdown'
+            inputConfig='data-ace-mode:yaml'}}
 
           {{input api_key_missing as='ace'
             class='row-fluid'
@@ -172,6 +178,12 @@
             class='row-fluid'
             labelTranslation='admin.api.settings.error_data_over_rate_limit'
             tooltipTranslation='admin.api.settings.error_data_over_rate_limit_tooltip_markdown'
+            inputConfig='data-ace-mode:yaml'}}
+
+          {{input https_required as='ace'
+            class='row-fluid'
+            labelTranslation='admin.api.settings.error_data_https_required'
+            tooltipTranslation='admin.api.settings.error_data_https_required_tooltip_markdown'
             inputConfig='data-ace-mode:yaml'}}
         {{/with}}
       {{/with}}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,18 @@ en:
           Error Code,Error Message
           {{code}},{{message}}
           ```
+        error_data_common: Common (All Errors)
+        error_data_common_tooltip_markdown: |-
+          <a href="http://en.wikipedia.org/wiki/YAML" target="_blank">YAML</a> definition of the Handlebars variables available to all error templates.
+
+          Default data:
+
+          ```
+          signup_url: {{base_url}}
+          contact_url: "{{base_url}}/contact/"
+          ```
+
+          `{{base_url}}` is a special variable that contains a reference to the current root URL of the domain being accessed (with no trailing slash). For example, if the API URL being accessed is `https://www.example.com/foo/bar.json` then `{{base_url}}` would be `https://www.example.com`.
         error_data_api_key_missing: API Key Missing
         error_data_api_key_missing_tooltip_markdown: |-
           <a href="http://en.wikipedia.org/wiki/YAML" target="_blank">YAML</a> definition of the Handlebars variables available to the error templates.
@@ -213,7 +225,7 @@ en:
           ```
           status_code: 403
           code: API_KEY_MISSING
-          message: No api_key was supplied. Get one at {{signupUrl}}
+          message: No api_key was supplied. Get one at {{signup_url}}
           ```
         error_data_api_key_invalid: API Key Invalid
         error_data_api_key_invalid_tooltip_markdown: |-
@@ -224,9 +236,8 @@ en:
           ```
           status_code: 403
           code: API_KEY_INVALID
-          message: An invalid api_key was supplied. Get one at {{signupUrl}}
+          message: An invalid api_key was supplied. Get one at {{signup_url}}
           ```
-
         error_data_api_key_disabled: API Key Disabled
         error_data_api_key_disabled_tooltip_markdown: |-
           <a href="http://en.wikipedia.org/wiki/YAML" target="_blank">YAML</a> definition of the Handlebars variables available to the error templates.
@@ -236,7 +247,7 @@ en:
           ```
           status_code: 403
           code: API_KEY_DISABLED
-          message: The api_key supplied has been disabled. Contact us at {{contactUrl}} for assistance
+          message: The api_key supplied has been disabled. Contact us at {{contact_url}} for assistance
           ```
         error_data_api_key_unauthorized: API Key Unauthorized
         error_data_api_key_unauthorized_tooltip_markdown: |-
@@ -247,7 +258,7 @@ en:
           ```
           status_code: 403
           code: API_KEY_UNAUTHORIZED
-          message: The api_key supplied is not authorized to access the given service. Contact us at {{contactUrl}} for assistance
+          message: The api_key supplied is not authorized to access the given service. Contact us at {{contact_url}} for assistance
           ```
         error_data_over_rate_limit: Over Rate Limit
         error_data_over_rate_limit_tooltip_markdown: |-
@@ -258,8 +269,21 @@ en:
           ```
           status_code: 429
           code: OVER_RATE_LIMIT
-          message: You have exceeded your rate limit. Try again later or contact us at {{contactUrl}} for assistance
+          message: You have exceeded your rate limit. Try again later or contact us at {{contact_url}} for assistance
           ```
+        error_data_https_required: HTTPS Required
+        error_data_https_required_tooltip_markdown: |-
+          <a href="http://en.wikipedia.org/wiki/YAML" target="_blank">YAML</a> definition of the Handlebars variables available to the error templates.
+
+          Default data:
+
+          ```
+          status_code: 400
+          code: HTTPS_REQUIRED
+          message: "Requests must be made over HTTPS. Try accessing the API at: {{https_url}}"
+          ```
+
+          `{{https_url}}` is a special variable that is available within the context of the HTTPS requirement error that contains a copy of the current URL with the URL schemed switched to HTTPS.
         allowed_ips_tooltip_markdown: |-
           Restrict this API key so that it may only be used from the specified IP addresses.
 

--- a/spec/features/admin/apis_spec.rb
+++ b/spec/features/admin/apis_spec.rb
@@ -288,11 +288,13 @@ describe "apis", :js => true do
     fill_in "JSON Template", :with => '{"foo":"bar"}'
     fill_in "XML Template", :with => "<foo>bar</foo>"
     fill_in "CSV Template", :with => "foo,bar\nbar,foo"
+    fill_in "Common (All Errors)", :with => "foo0: bar0\nbar0: foo0"
     fill_in "API Key Missing", :with => "foo1: bar1\nbar1: foo1"
     fill_in "API Key Invalid", :with => "foo2: bar2\nbar2: foo2"
     fill_in "API Key Disabled", :with => "foo3: bar3\nbar3: foo3"
     fill_in "API Key Unauthorized", :with => "foo4: bar4\nbar4: foo4"
     fill_in "Over Rate Limit", :with => "foo5: bar5\nbar5: foo5"
+    fill_in "HTTPS Required", :with => "foo6: bar6\nbar6: foo6"
 
     click_button("Save")
     page.should have_content("Successfully saved")


### PR DESCRIPTION
See https://github.com/18F/api.data.gov/issues/285 and associated pull request: https://github.com/NREL/api-umbrella-gatekeeper/pull/21
